### PR TITLE
Update Guzzle for PHP8.4 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=5.5",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^7.0"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.0",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description

When updating to PHP8.4 there was an incompatibility with the guzzlehttp/promises package, which is required by the guzzlehttp/guzzle helpspot is using.

The minimum version of the compatible version is set to PHP7.0. Older users can keep using the older package, php8.4 users can use this new version

## Motivation and context

Create compatible version for php8.4

## How has this been tested?

Implemented the change in php8.4 and could run without errors.

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document. **(document doesn't exist)**
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature. **updated in master in own fork**
- [x] Each individual commit in the pull request is meaningful. **only 1 commit, for this small change**
- [x] I have added tests to cover my changes. **no tests in the project**
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
